### PR TITLE
Fix TOWER_TOP declaration for GCC10

### DIFF
--- a/src/trie.c
+++ b/src/trie.c
@@ -106,6 +106,7 @@ int      recursive_count_nodes (node_t * node, int, int);
 
 // Globals.
 int ERROR = 0;
+gstack_t * const TOWER_TOP;
 
 int get_height(trie_t *trie) { return trie->info->height; }
 

--- a/src/trie.h
+++ b/src/trie.h
@@ -54,7 +54,7 @@ typedef struct trie_t trie_t;
 #define MAXBRCDLEN 1023     // Maximum barcode length.
 #define GSTACK_INIT_SIZE 16 // Initial slots of 'gstack'.
 
-gstack_t * const TOWER_TOP;
+extern gstack_t * const TOWER_TOP;
 
 int         check_trie_error_and_reset (void);
 int         count_nodes (trie_t*);


### PR DESCRIPTION
Compiling with GCC10 fails with error:
```
gcc -std=c99 -O3 -Wall -Wextra src/main-starcode.c src/trie.o src/starcode.o -lpthread -lm -o starcode
/usr/bin/ld: src/starcode.o:(.rodata+0x5c0): multiple definition of `TOWER_TOP'; src/trie.o:(.rodata+0x800): first defined here
```

This happens because TOWER_TOP is a global variable but not properly declared as such. See [here](https://gcc.gnu.org/gcc-10/porting_to.html#common).

Please consider for merging.